### PR TITLE
[feat] #21 ArticleController 구현

### DIFF
--- a/src/main/java/com/spring/guideance/post/controller/ArticleController.java
+++ b/src/main/java/com/spring/guideance/post/controller/ArticleController.java
@@ -1,4 +1,103 @@
 package com.spring.guideance.post.controller;
 
+import com.spring.guideance.post.dto.request.*;
+import com.spring.guideance.post.dto.response.ResponseArticleDto;
+import com.spring.guideance.post.dto.response.ResponseSimpleArticleDto;
+import com.spring.guideance.post.service.ArticleService;
+import com.spring.guideance.tag.service.TagService;
+import com.spring.guideance.user.service.NoticeService;
+import com.spring.guideance.util.api.ApiResponse;
+import com.spring.guideance.util.exception.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/article")
+@RequiredArgsConstructor
 public class ArticleController {
+
+    private final ArticleService articleService;
+    private final TagService tagService;
+    private final NoticeService noticeService;
+
+    // 게시물 목록 조회 (제목, 내용, 작성자, 좋아요 수, 댓글 수)
+    @GetMapping
+    public ApiResponse<List<ResponseSimpleArticleDto>> getArticles() {
+        return ApiResponse.success(articleService.getArticles(), ResponseCode.ARTICLE_FOUND.getMessage());
+    }
+
+    // 특정 게시물 정보 조회 (제목, 내용, 댓글 목록, 좋아요 목록, 작성자, 작성일시)
+    @GetMapping("/{articleId}")
+    public ApiResponse<ResponseArticleDto> getSingleArticle(@PathVariable Long articleId) {
+        return ApiResponse.success(articleService.getSingleArticle(articleId), ResponseCode.ARTICLE_FOUND.getMessage());
+    }
+
+    // 게시물 검색
+    @GetMapping("/search/{articleName}")
+    public ApiResponse<List<ResponseSimpleArticleDto>> searchArticles(@PathVariable String articleName) {
+        return ApiResponse.success(articleService.searchArticles(articleName), ResponseCode.ARTICLE_FOUND.getMessage());
+    }
+
+    // 게시물 작성
+    @PostMapping
+    public ApiResponse<Long> createArticle(@RequestBody CreateArticleDto articleDto) {
+        Long articleId = articleService.createArticle(articleDto);
+        tagService.addTagToArticle(articleId, articleDto.getTags());
+        // 게시물이 생성되면 게시물이 가진 태그들을 구독하는 사람들에게 Notice를 생성하여 전송하는 기능 필요
+        return ApiResponse.success(articleId, ResponseCode.ARTICLE_CREATED.getMessage());
+    }
+
+    // 게시물 수정
+    @PutMapping("/{articleId}")
+    public ApiResponse<Void> updateArticle(@PathVariable Long articleId, @RequestBody UpdateArticleDto articleDto) {
+        articleService.updateArticle(articleId, articleDto);
+        return ApiResponse.success(null, ResponseCode.ARTICLE_UPDATED.getMessage());
+    }
+
+    // 게시물 삭제
+    @DeleteMapping("/{articleId}")
+    public ApiResponse<Void> deleteArticle(@PathVariable Long articleId, @RequestBody DeleteArticleDto articleDto) {
+        articleService.deleteArticle(articleId, articleDto);
+        return ApiResponse.success(null, ResponseCode.ARTICLE_DELETED.getMessage());
+    }
+
+    // 게시물에 댓글 작성
+    @PostMapping("/{articleId}/comment")
+    public ApiResponse<Long> createComment(@PathVariable Long articleId, @RequestBody CreateCommentDto commentDto) {
+        Long commentId = articleService.createComment(articleId, commentDto);
+        // 댓글이 작성되면 게시물 작성자에게 Notice를 생성하여 전송하는 기능 필요
+        return ApiResponse.success(commentId, ResponseCode.COMMENT_CREATED.getMessage());
+    }
+
+    // 게시물에 댓글 수정
+    @PutMapping("/comment/{commentId}")
+    public ApiResponse<Void> updateComment(@PathVariable Long commentId, @RequestBody UpdateCommentDto commentDto) {
+        articleService.updateComment(commentId, commentDto);
+        return ApiResponse.success(null, ResponseCode.COMMENT_UPDATED.getMessage());
+    }
+
+    // 게시물에 댓글 삭제
+    @DeleteMapping("/comment/{commentId}")
+    public ApiResponse<Void> deleteComment(@PathVariable Long commentId, @RequestBody DeleteCommentDto commentDto) {
+        articleService.deleteComment(commentDto);
+        return ApiResponse.success(null, ResponseCode.COMMENT_DELETED.getMessage());
+    }
+
+    // 게시물에 좋아요
+    @PostMapping("/{articleId}/like")
+    public ApiResponse<Long> like(@PathVariable Long articleId, @RequestBody RequestLikeDto requestLikeDto) {
+        Long likeId = articleService.createLikes(articleId, requestLikeDto);
+        // 좋아요가 생성되면 게시물 작성자에게 Notice를 생성하여 전송하는 기능 필요
+        return ApiResponse.success(likeId, ResponseCode.LIKE_CREATED.getMessage());
+    }
+
+    // 게시물에 좋아요 취소
+    @PostMapping("/{articleId}/like/cancel")
+    public ApiResponse<Void> cancelLike(@PathVariable Long articleId, @RequestBody RequestLikeDto requestLikeDto) {
+        articleService.deleteLikes(articleId, requestLikeDto);
+        return ApiResponse.success(null, ResponseCode.LIKE_DELETED.getMessage());
+    }
+
 }

--- a/src/main/java/com/spring/guideance/post/controller/ArticleController.java
+++ b/src/main/java/com/spring/guideance/post/controller/ArticleController.java
@@ -45,7 +45,7 @@ public class ArticleController {
     public ApiResponse<Long> createArticle(@RequestBody CreateArticleDto articleDto) {
         Long articleId = articleService.createArticle(articleDto);
         tagService.addTagToArticle(articleId, articleDto.getTags());
-        // 게시물이 생성되면 게시물이 가진 태그들을 구독하는 사람들에게 Notice를 생성하여 전송하는 기능 필요
+        noticeService.sendNoticeForNewArticle(articleId); // 게시물이 가진 태그들을 구독하는 사람들에게 알림전송
         return ApiResponse.success(articleId, ResponseCode.ARTICLE_CREATED.getMessage());
     }
 
@@ -67,7 +67,7 @@ public class ArticleController {
     @PostMapping("/{articleId}/comment")
     public ApiResponse<Long> createComment(@PathVariable Long articleId, @RequestBody CreateCommentDto commentDto) {
         Long commentId = articleService.createComment(articleId, commentDto);
-        // 댓글이 작성되면 게시물 작성자에게 Notice를 생성하여 전송하는 기능 필요
+        noticeService.sendNoticeForComment(commentId); // 게시물 작성자에게 댓글 알림전송
         return ApiResponse.success(commentId, ResponseCode.COMMENT_CREATED.getMessage());
     }
 
@@ -89,7 +89,7 @@ public class ArticleController {
     @PostMapping("/{articleId}/like")
     public ApiResponse<Long> like(@PathVariable Long articleId, @RequestBody RequestLikeDto requestLikeDto) {
         Long likeId = articleService.createLikes(articleId, requestLikeDto);
-        // 좋아요가 생성되면 게시물 작성자에게 Notice를 생성하여 전송하는 기능 필요
+        noticeService.sendNoticeForLike(likeId); // 게시물 작성자에게 좋아요 알림전송
         return ApiResponse.success(likeId, ResponseCode.LIKE_CREATED.getMessage());
     }
 

--- a/src/main/java/com/spring/guideance/post/dto/request/UpdateCommentDto.java
+++ b/src/main/java/com/spring/guideance/post/dto/request/UpdateCommentDto.java
@@ -7,12 +7,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateCommentDto {
     private Long userId;
-    private Long commentId;
     private String contents;
 
-    public UpdateCommentDto(Long userId, Long commentId, String contents) {
+    public UpdateCommentDto(Long userId, String contents) {
         this.userId = userId;
-        this.commentId = commentId;
         this.contents = contents;
     }
 }

--- a/src/main/java/com/spring/guideance/post/service/ArticleService.java
+++ b/src/main/java/com/spring/guideance/post/service/ArticleService.java
@@ -86,10 +86,6 @@ public class ArticleService {
         Article article = Article.createArticle(articleDto);
         User user = userRepository.findById(articleDto.getUserId()).orElseThrow(() -> new ArticleException(ResponseCode.USER_NOT_FOUND));
         article.setUser(user);
-
-        /**
-         * 태그 관련 로직은 추후 추가
-         */
         return articleRepository.save(article).getId();
     }
 
@@ -145,9 +141,7 @@ public class ArticleService {
     private Comment commentAuthorCheck(Long commentId, Long userId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new ArticleException(ResponseCode.COMMENT_NOT_FOUND));
         User user = userRepository.findById(userId).orElseThrow(() -> new ArticleException(ResponseCode.USER_NOT_FOUND));
-        if (!comment.isAuthor(user)) {
-            throw new ArticleException(ResponseCode.METHOD_NOT_ALLOWED);
-        }
+        if (!comment.isAuthor(user)) throw new ArticleException(ResponseCode.METHOD_NOT_ALLOWED);
         return comment;
     }
 

--- a/src/main/java/com/spring/guideance/post/service/ArticleService.java
+++ b/src/main/java/com/spring/guideance/post/service/ArticleService.java
@@ -128,8 +128,8 @@ public class ArticleService {
 
     // 게시물에 댓글 수정
     @Transactional
-    public void updateComment(UpdateCommentDto commentDto) {
-        Comment comment = commentAuthorCheck(commentDto.getCommentId(), commentDto.getUserId());
+    public void updateComment(Long commentId, UpdateCommentDto commentDto) {
+        Comment comment = commentAuthorCheck(commentId, commentDto.getUserId());
         comment.updateComment(commentDto.getContents());
         commentRepository.save(comment);
     }

--- a/src/main/java/com/spring/guideance/user/controller/UserController.java
+++ b/src/main/java/com/spring/guideance/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.spring.guideance.user.dto.request.LoginUserDto;
 import com.spring.guideance.user.dto.request.UpdateUserDto;
 import com.spring.guideance.user.dto.response.ResponseNoticeDto;
 import com.spring.guideance.user.dto.response.ResponseUserDto;
+import com.spring.guideance.user.service.NoticeService;
 import com.spring.guideance.user.service.UserService;
 import com.spring.guideance.util.api.ApiResponse;
 import com.spring.guideance.util.exception.ResponseCode;
@@ -22,6 +23,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final NoticeService noticeService;
 
     // 회원가입
     @PostMapping("/create")
@@ -84,6 +86,20 @@ public class UserController {
     @GetMapping("/{userId}/articles/likes")
     public ApiResponse<List<ResponseSimpleArticleDto>> getLikes(@PathVariable Long userId) {
         return ApiResponse.success(userService.getUserLikesArticles(userId), ResponseCode.ARTICLE_FOUND.getMessage());
+    }
+
+    // 유저가 특정 알림을 읽음
+    @PostMapping("/{userId}/notices/{noticeId}/read")
+    public ApiResponse<Void> readNotice(@PathVariable Long userId, @PathVariable Long noticeId) {
+        noticeService.readUserNotice(noticeId);
+        return ApiResponse.success(null, ResponseCode.NOTICE_READ.getMessage());
+    }
+
+    // 유저가 특정 알림을 삭제
+    @DeleteMapping("/{userId}/notices/{noticeId}/delete")
+    public ApiResponse<Void> deleteNotice(@PathVariable Long userId, @PathVariable Long noticeId) {
+        noticeService.deleteUserNotice(noticeId);
+        return ApiResponse.success(null, ResponseCode.NOTICE_DELETED.getMessage());
     }
 
 }

--- a/src/main/java/com/spring/guideance/user/domain/Notice.java
+++ b/src/main/java/com/spring/guideance/user/domain/Notice.java
@@ -1,5 +1,7 @@
 package com.spring.guideance.user.domain;
 
+import com.spring.guideance.util.exception.NoticeException;
+import com.spring.guideance.util.exception.ResponseCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,11 +26,25 @@ public class Notice {
     private List<UserNotice> userNotices = new ArrayList<>();
 
     // 생성 메서드
-    public static Notice createNotice(int type, String title, String contents) {
+    public static Notice createNotice(int type, String userName, String contents) {
         Notice notice = new Notice();
         notice.type = type;
-        notice.title = title;
-        notice.contents = contents;
+        switch (type) {
+            case 1:
+                notice.title = userName + "님이 내 게시물에 좋아요를 눌렀습니다.";
+                notice.contents = contents; // 게시물 제목
+                break;
+            case 2:
+                notice.title = userName + "님이 내 게시물에 댓글을 남겼습니다.";
+                notice.contents = contents; // 댓글 내용
+                break;
+            case 3:
+                notice.title = "구독 중인 태그에 새 게시물이 추가되었습니다.";
+                notice.contents = contents; // 게시물 제목
+                break;
+            default:
+                throw new NoticeException(ResponseCode.NOTICE_TYPE_WRONG);
+        }
         return notice;
     }
 }

--- a/src/main/java/com/spring/guideance/user/domain/Notice.java
+++ b/src/main/java/com/spring/guideance/user/domain/Notice.java
@@ -1,5 +1,6 @@
 package com.spring.guideance.user.domain;
 
+import com.spring.guideance.util.NoticeType;
 import com.spring.guideance.util.exception.NoticeException;
 import com.spring.guideance.util.exception.ResponseCode;
 import lombok.Getter;
@@ -16,7 +17,7 @@ public class Notice {
     @Column(name = "notice_id")
     private Long id;
 
-    private int type; // 게시글에 좋아요 발생, 게시글에 댓글 발생, 구독한 태그에 새로운 게시글 등장
+    private NoticeType type; // 게시글에 좋아요 발생, 게시글에 댓글 발생, 구독한 태그에 새로운 게시글 등장
 
     private String title;
 
@@ -28,7 +29,7 @@ public class Notice {
     // 생성 메서드
     public static Notice createNotice(int type, String userName, String contents) {
         Notice notice = new Notice();
-        notice.type = type;
+        notice.type = NoticeType.findByCode(type);
         switch (type) {
             case 1:
                 notice.title = userName + "님이 내 게시물에 좋아요를 눌렀습니다.";

--- a/src/main/java/com/spring/guideance/user/dto/response/ResponseNoticeDto.java
+++ b/src/main/java/com/spring/guideance/user/dto/response/ResponseNoticeDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class ResponseNoticeDto {
     private Long id;
-    private int type;
+    private String type;
     private String title;
     private String contents;
     private LocalDateTime createdAt;
@@ -18,7 +18,7 @@ public class ResponseNoticeDto {
 
     public ResponseNoticeDto(UserNotice userNotice) {
         this.id = userNotice.getId();
-        this.type = userNotice.getNotice().getType();
+        this.type = userNotice.getNotice().getType().getDescription();
         this.title = userNotice.getNotice().getTitle();
         this.contents = userNotice.getNotice().getContents();
         this.createdAt = userNotice.getCreatedAt();

--- a/src/main/java/com/spring/guideance/user/service/NoticeService.java
+++ b/src/main/java/com/spring/guideance/user/service/NoticeService.java
@@ -1,7 +1,7 @@
 package com.spring.guideance.user.service;
 
+import com.spring.guideance.user.domain.Notice;
 import com.spring.guideance.user.domain.UserNotice;
-import com.spring.guideance.user.dto.response.ResponseNoticeDto;
 import com.spring.guideance.user.dto.response.ResponseUserDto;
 import com.spring.guideance.user.repository.NoticeRepository;
 import com.spring.guideance.user.repository.UserNoticeRepository;
@@ -23,48 +23,43 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final UserNoticeRepository userNoticeRepository;
 
-    // 알림 생성
-    @Transactional
-    public Long createNotice(Long noticeId, Long userId) {
-        noticeRepository.findById(noticeId).orElseThrow(() -> new NoticeException(ResponseCode.NOTICE_NOT_FOUND));
-        return userNoticeRepository.save(UserNotice.createUserNotice(noticeRepository.findById(noticeId).get(), userRepository.findById(userId).get())).getId();
-    }
-
-    // 특정 user가 받은 모든 알림 조회
-    public List<ResponseNoticeDto> getUserNotice(Long userId) {
-        List<UserNotice> userNoticeList = userNoticeRepository.findByUserId(userId);
-        return userNoticeList.stream().map(ResponseNoticeDto::new).collect(Collectors.toList());
-    }
-
-    // 특정 user가 받은 특정 알림 삭제
-    @Transactional
-    public void deleteUserNotice(Long userNoticeId) {
-        userNoticeRepository.deleteById(userNoticeId);
-    }
-
-    // 특정 user가 받은 특정 알림을 읽음
-    public void readUserNotice(Long userNoticeId) {
-        UserNotice userNotice = userNoticeRepository.findById(userNoticeId).orElseThrow(() -> new NoticeException(ResponseCode.NOTICE_NOT_FOUND));
-        userNotice.read();
-    }
-
-    // 특정 알림을 받은 모든 user 조회
-    public List<ResponseUserDto> getUserNoticeUser(Long noticeId) {
-        List<UserNotice> userNoticeList = userNoticeRepository.findByNoticeId(noticeId);
-        return userNoticeList.stream().map(userNotice -> new ResponseUserDto(userNotice.getUser())).collect(Collectors.toList());
-    }
 
     /**
-     * 아래 메서드는 Controller에서 2개 이상의 Service를 호출해야 하는 경우
-     * (예를 들어, Controller에서 좋아요 API가 실행되면 좋아요를 DB에 좋아요를 반영하기 위해 ArticleService가 호출되고,
-     * 이후 유저에게 좋아요 알림을 보내야 하므로 NoticeService가 호출되어야 함)
-     * 에 대응하는 복합적인 메서드이므로 Controller 파일 생성 후 전반적인 구도가 잡힌 뒤 구현 예정
+     * 알림 생성+전송 기능
      */
 
     // 특정 게시물의 주인 user에게 누군가 좋아요를 눌렀음을 알림
 
     // 특정 게시물의 주인 user에게 누군가 댓글을 달았음을 알림
 
-    // 특정 태그를 구독 중인 user들에게 새 게시물이 추가되었음을 알림을
+    // 특정 태그를 구독 중인 user들에게 새 게시물이 추가되었음을 알림
+
+    /**
+     * 알림 조회/삭제/읽음 관련 기능
+     */
+
+    // 특정 user가 받은 특정 알림 삭제 -> UserController에서 사용
+    @Transactional
+    public void deleteUserNotice(Long userNoticeId) {
+        userNoticeRepository.deleteById(userNoticeId);
+    }
+
+    // 특정 user가 받은 특정 알림을 읽음 -> UserController에서 사용
+    @Transactional
+    public void readUserNotice(Long userNoticeId) {
+        UserNotice userNotice = userNoticeRepository.findById(userNoticeId).orElseThrow(() -> new NoticeException(ResponseCode.NOTICE_NOT_FOUND));
+        userNotice.read();
+    }
+
+    // 전체 알림 조회 - 관리자 기능
+    public List<Notice> getNoticeList() {
+        return noticeRepository.findAll();
+    }
+
+    // 특정 알림을 받은 모든 user 조회 - 관리자 기능
+    public List<ResponseUserDto> getUserNoticeUser(Long noticeId) {
+        List<UserNotice> userNoticeList = userNoticeRepository.findByNoticeId(noticeId);
+        return userNoticeList.stream().map(userNotice -> new ResponseUserDto(userNotice.getUser())).collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/com/spring/guideance/util/NoticeType.java
+++ b/src/main/java/com/spring/guideance/util/NoticeType.java
@@ -1,0 +1,32 @@
+package com.spring.guideance.util;
+
+public enum NoticeType {
+    LIKE(1, "Like"),
+    COMMENT(2, "Comment"),
+    TAG_SUB(3, "TagSub");
+
+    private final int code;
+    private final String description;
+
+    NoticeType(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public static NoticeType findByCode(int code) {
+        for (NoticeType noticeType : NoticeType.values()) {
+            if (noticeType.getCode() == code) {
+                return noticeType;
+            }
+        }
+        return null;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/spring/guideance/util/exception/ResponseCode.java
+++ b/src/main/java/com/spring/guideance/util/exception/ResponseCode.java
@@ -12,6 +12,7 @@ public enum ResponseCode {
     // 400 Bad Request
     BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
     UNSUBSCRIBE_TAG(HttpStatus.BAD_REQUEST, false, "구독하지 않은 태그입니다."),
+    NOTICE_TYPE_WRONG(HttpStatus.BAD_REQUEST, false, "알림을 찾을 수 없습니다."),
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
@@ -35,6 +36,7 @@ public enum ResponseCode {
     // 200 OK
     USER_LOGINED(HttpStatus.OK, true, "로그인 되었습니다."),
     TAG_UNSUBSCRIBED(HttpStatus.CREATED, true, "태그 구독이 취소되었습니다."),
+    NOTICE_READ(HttpStatus.CREATED, true, "알림을 읽었습니다."),
     USER_UPDATED(HttpStatus.CREATED, true, "사용자 정보가 수정되었습니다."),
     ARTICLE_UPDATED(HttpStatus.CREATED, true, "게시글이 수정되었습니다."),
     COMMENT_UPDATED(HttpStatus.CREATED, true, "댓글이 수정되었습니다."),


### PR DESCRIPTION
* 게시물과 관련된 기능을 관리하는 ArticleController 구현
* 구현 완료 시 3종 Controller에 분산되어 있는 NoticeService의 알림 생성/전송/삭제 기능 구현
* 알림은 자신의 게시물에 누군가가 좋아요 알림, 자신의 게시물에 누군가 댓글 알림, 구독한 주제 새 게시물 업로드 알림으로 구성
* 대댓글 기능은 구현하지 않음 (커뮤니티가 아닌 순수 피드백 측면에 집중)
# Todo
* API 명세서 작성 및 버그 수정
* Redis 도입하여 푸시알림 구현